### PR TITLE
LuaU parser fix

### DIFF
--- a/src/luau.rs
+++ b/src/luau.rs
@@ -92,7 +92,7 @@ pub fn bytecode(input: &[u8]) -> IResult<&[u8], LuaChunk> {
     let (mut input, _version) = le_u8(input)?;
     let mut types_version = 0;
 
-    if _version > 4 {
+    if _version >= 4 {
         let (input2, _types_version) = le_u8(input)?;
         types_version = _types_version;
         input = input2


### PR DESCRIPTION
I was able to add the [missing flags, type information, and type version](https://github.com/luau-lang/luau/blob/4b2af900c28598a18221e4798b72b16010ce7f2a/Compiler/src/BytecodeBuilder.cpp#L620) to the parser by using the LuaU source as a reference ([here](https://github.com/luau-lang/luau/blob/4b2af900c28598a18221e4798b72b16010ce7f2a/VM/src/lvmload.cpp#L196) and [here](https://github.com/luau-lang/luau/blob/4b2af900c28598a18221e4798b72b16010ce7f2a/VM/src/lvmload.cpp#L228)) although I didn't add it to the LuaChunk struct. This should maintain compatibility because of the version checks. I'd like to see if it's OK to merge and ask for any improvements on the code because it is sort of messy.