### PR TITLE
lua53 Constant string length over 254

### DIFF
--- a/src/lua53.rs
+++ b/src/lua53.rs
@@ -139,7 +139,11 @@ fn take_lv_float(input: &[u8]) -> IResult<&[u8], LuaConstant> {
 }
 
 fn le_u8_minus_one(input: &[u8]) -> IResult<&[u8], u8> {
-    let (input, out) = le_u8(input)?;
+    let (mut input, out) = le_u8(input)?;
+    if out == 0xFF {
+        // TODO: usize
+        (input, out) = complete::le_u64(input)?;
+    }
     Ok((input, out - 1))
 }
 


### PR DESCRIPTION
test lua code `s260.lua`
```lua
print("000000001 000000002 000000003 000000004 000000005 000000006 000000007 000000008 000000009 000000010 000000011 000000012 000000013 000000014 000000015 000000016 000000017 000000018 000000019 000000020 000000021 000000022 000000023 000000024 000000025 000000026 ")
```

test compiler command `luac53.exe s260.lua`

Website Error while lua 5.3 string length over 254.